### PR TITLE
Update Get-MGUserLicenseReport.ps1

### DIFF
--- a/Cmdlet/Get-MGUserLicenseReport.ps1
+++ b/Cmdlet/Get-MGUserLicenseReport.ps1
@@ -92,7 +92,9 @@ Function Get-MGUserLicenseReport {
     $Output.Add($Object) | Out-Null
 
     # Make sure our UserToProcess array is created and is null
-    $UserToProcess = $null
+    if ($null -eq $Users) {
+    	$UserToProcess = $null
+	}
 
     # See if our user array is null and pull all users if needed
     if ($null -eq $Users) {


### PR DESCRIPTION
Setting the $userstoadd variable to null creates a problem when using .add (it isn't able to add the results of get-mguser). initializing the variable, but not setting it to null looks to avoid this issue.

It doesn't have an effect either way when you are pulling all the users in the tenant, but i've updated it so that it will still operate as before IF a user variable is not presented.

Before making this change, I wasn't able to use the report in Win11 to do anything other than all users in the tenant. 